### PR TITLE
[Fix] the problem that sample rules could not be loaded and registerd normally

### DIFF
--- a/src/main/java/org/sonar/cxx/checks/UsingNamespaceCheck.java
+++ b/src/main/java/org/sonar/cxx/checks/UsingNamespaceCheck.java
@@ -14,7 +14,8 @@ import org.sonar.cxx.tag.Tag;
   key = "UsingNamespace",
   priority = Priority.BLOCKER,
   name = "Using namespace directives are not allowed",
-  tags = {Tag.CONVENTION})
+  tags = {Tag.CONVENTION},
+  description = "Using namespace directives are not allowed.")
 @SqaleConstantRemediation("5min")
 @ActivatedByDefault
 public class UsingNamespaceCheck extends SquidCheck<Grammar> {


### PR DESCRIPTION
I did the following checks and tests to verify:
The latest https://github.com/SonarOpenCommunity/sonar-cxx (commit id 04508e8446e236e9044c5411229be7dee1554355) and the latest https://github.com/SonarOpenCommunity/cxx-custom-checks-example-plugin (commit id https://github.com/SonarOpenCommunity/cxx-custom-checks-example-plugin/commit/55b0738ed5856762dc812c1a26aecbbed4496063 812c1a26aecbbed4496063), they is not work. I understand that we need to set their html prompt information for each rule.
![image](https://github.com/SonarOpenCommunity/cxx-custom-checks-example-plugin/assets/137695008/b4bf4e5f-2312-4223-a3ec-f8b7d85f0536)
