### PR TITLE
using HTML description

### DIFF
--- a/src/main/java/org/sonar/cxx/MyCustomRulesDefinition.java
+++ b/src/main/java/org/sonar/cxx/MyCustomRulesDefinition.java
@@ -7,12 +7,14 @@ public class MyCustomRulesDefinition extends CustomCxxRulesDefinition {
 
   @Override
   public String repositoryName() {
-    return "MyCustomCxxRepository";
+    return "Custom CXX";
   }
 
   @Override
   public String repositoryKey() {
-    return "mycustomcxxrepo";
+    // The html descriptions for the rules of repository must be stored in the path '/org/sonar/l10n/cxx/rules/mycxx'.
+    // If the return value of 'repositoryKey' is changed, the storage location in 'resources' must also be adjusted.
+    return "mycxx";
   }
 
   @SuppressWarnings("rawtypes")

--- a/src/main/java/org/sonar/cxx/checks/UsingNamespaceCheck.java
+++ b/src/main/java/org/sonar/cxx/checks/UsingNamespaceCheck.java
@@ -10,12 +10,16 @@ import org.sonar.cxx.squidbridge.annotations.SqaleConstantRemediation;
 import org.sonar.cxx.squidbridge.checks.SquidCheck;
 import org.sonar.cxx.tag.Tag;
 
+// In case you are adding a .html description in resources, the .html file name should match the rule key.
+// In this sample the name must be 'UsingNamespace.html'.
 @Rule(
   key = "UsingNamespace",
-  priority = Priority.BLOCKER,
-  name = "Using namespace directives are not allowed",
-  tags = {Tag.CONVENTION},
-  description = "Using namespace directives are not allowed.")
+   priority = Priority.BLOCKER,
+   name = "Using namespace directives are not allowed",
+   tags = {Tag.CONVENTION}
+// second possibility to add a rule description:
+//,description = "Using namespace directives are not allowed."
+)
 @SqaleConstantRemediation("5min")
 @ActivatedByDefault
 public class UsingNamespaceCheck extends SquidCheck<Grammar> {

--- a/src/main/java/org/sonar/cxx/checks/package-info.java
+++ b/src/main/java/org/sonar/cxx/checks/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package org.sonar.cxx.checks;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/org/sonar/cxx/package-info.java
+++ b/src/main/java/org/sonar/cxx/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package org.sonar.cxx;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/resources/org/sonar/l10n/cxx/rules/mycxx/UsingNamespace.html
+++ b/src/main/resources/org/sonar/l10n/cxx/rules/mycxx/UsingNamespace.html
@@ -1,7 +1,7 @@
 <p>
 Using namespace directives are not allowed.
 
-Using-directives (using namespace foo) are dangerous enough to be banned by the Google style guide. Don’t use them in code that will ever need to be upgraded.
+Using-directives (using namespace foo) are dangerous enough to be banned by the Google style guide. Don't use them in code that will ever need to be upgraded.
 If you wish to shorten a name, you may instead use a namespace alias (namespace baz = ::foo::bar::baz;) or a using-declaration (using ::foo::SomeName), both of which are permitted by the style guide in certain contexts (e.g. in *.cc files).
 </p>
 
@@ -15,6 +15,7 @@ class MyClass {
 </pre>
 
 <h2>Compliant Sample</h2>
+<p>ToDo</p>
 
 <pre>
 class MyClass {

--- a/src/test/java/org/sonar/cxx/MyCustomRulesDefinitionTest.java
+++ b/src/test/java/org/sonar/cxx/MyCustomRulesDefinitionTest.java
@@ -8,8 +8,8 @@ public class MyCustomRulesDefinitionTest {
   @Test
   public void test() {
     MyCustomRulesDefinition definition = new MyCustomRulesDefinition();
-    assertThat(definition.repositoryName()).isEqualTo("MyCustomCxxRepository");
-    assertThat(definition.repositoryKey()).isEqualTo("mycustomcxxrepo");
+    assertThat(definition.repositoryName()).isEqualTo("Custom CXX");
+    assertThat(definition.repositoryKey()).isEqualTo("mycxx");
     assertThat(definition.checkClasses().length).isEqualTo(1);
   }
 


### PR DESCRIPTION
-  The html descriptions for the rules of repository must be stored in the path '/org/sonar/l10n/cxx/rules/mycxx'. If the return value of 'repositoryKey' is changed, the storage location in 'resources' must also be adjusted.